### PR TITLE
added 'template' column to survey table

### DIFF
--- a/src/db/dbMigrator/migration/public/migrations/sqls/20180726092435-create-survey-def-tables-up.sql
+++ b/src/db/dbMigrator/migration/public/migrations/sqls/20180726092435-create-survey-def-tables-up.sql
@@ -6,6 +6,7 @@ CREATE TABLE
   id            bigint    NOT NULL GENERATED ALWAYS AS IDENTITY,
   uuid          uuid      NOT NULL UNIQUE DEFAULT uuid_generate_v4(),
 
+  template      boolean   NOT NULL DEFAULT false,
   published     boolean   NOT NULL DEFAULT false,
   draft         boolean   NOT NULL DEFAULT true,
 


### PR DESCRIPTION
In order to add the 'template' column to the survey table, I'm just modifying the existing db migration, instead of creating a new one, since we are still in the dev environment.
Template column will be used by Arena to filter the surveys marked as 'template'.