### PR TITLE
db transform callback: always associate 'published' and 'draft' when backup is true

### DIFF
--- a/src/db/dbs/transformCallback.ts
+++ b/src/db/dbs/transformCallback.ts
@@ -28,7 +28,7 @@ export const transformCallback = (options: {
   }
 
   // Assoc published and draft properties based on props
-  const currentRow = assocPublishedDraft ? _assocPublishedDraft(row) : row
+  const currentRow = backup || assocPublishedDraft ? _assocPublishedDraft(row) : row
   const rowUpdated = Objects.camelize({ object: currentRow, skip: ['validation', 'props', 'props_draft'] })
 
   if (!backup) {


### PR DESCRIPTION
…rties to items when backup is true

## Description

<!--- List the changes proposed and/or how the issue(s) has(have) been solved. -->

Small change to db transform callback generic function.
Including this function simplifies the use of items fetched from the db.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has this been tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Do you consider this PR needs further testing?

- [x] No
- [ ] Yes

<!--- If Yes, describe why or what to do next -->

## Disclaimer

<!--- Provide a description about anything unusual. -->
