### PR TITLE
Add optional header and footer images to survey DOCX/PDF export

### DIFF
--- a/src/service/survey/docExport/surveyDocImages.ts
+++ b/src/service/survey/docExport/surveyDocImages.ts
@@ -63,16 +63,13 @@ const fetchSurveyDocImage = async (
 
 export const fetchSurveyDocImages = async (
   options: Pick<SurveyDocOptions, 'fileProvider' | 'headerImageFileUuid' | 'footerImageFileUuid'>,
-  limits: { maxWidth: number; maxHeight?: number } = {
-    maxWidth: DOC_CONTENT_MAX_WIDTH,
-    maxHeight: DOC_HEADER_FOOTER_MAX_HEIGHT,
-  }
+  limits: { maxWidth?: number; maxHeight?: number } = {}
 ): Promise<{ headerImage?: SurveyDocImageData; footerImage?: SurveyDocImageData }> => {
   const { fileProvider, headerImageFileUuid, footerImageFileUuid } = options
-  const maxHeight = limits.maxHeight ?? DOC_HEADER_FOOTER_MAX_HEIGHT
+  const { maxWidth = DOC_CONTENT_MAX_WIDTH, maxHeight = DOC_HEADER_FOOTER_MAX_HEIGHT } = limits
   const [headerImage, footerImage] = await Promise.all([
-    fetchSurveyDocImage(headerImageFileUuid, fileProvider, limits.maxWidth, maxHeight),
-    fetchSurveyDocImage(footerImageFileUuid, fileProvider, limits.maxWidth, maxHeight),
+    fetchSurveyDocImage(headerImageFileUuid, fileProvider, maxWidth, maxHeight),
+    fetchSurveyDocImage(footerImageFileUuid, fileProvider, maxWidth, maxHeight),
   ])
 
   return { headerImage, footerImage }

--- a/src/service/survey/docExport/surveyDocImages.ts
+++ b/src/service/survey/docExport/surveyDocImages.ts
@@ -1,0 +1,79 @@
+import sizeOf from 'image-size'
+
+import { calculateScaledDimensions, getImageDimensions } from '../docxExport/ImageUtils'
+import type { SurveyDocOptions } from './types'
+
+type DocxImageType = 'jpg' | 'png' | 'gif' | 'bmp'
+
+const DOCX_IMAGE_TYPE_BY_FORMAT: Record<string, DocxImageType> = {
+  jpg: 'jpg',
+  jpeg: 'jpg',
+  png: 'png',
+  gif: 'gif',
+  bmp: 'bmp',
+}
+
+export const DOC_CONTENT_MAX_WIDTH = 650
+export const DOC_HEADER_FOOTER_MAX_HEIGHT = 120
+
+export interface SurveyDocImageData {
+  buffer: Buffer
+  width: number
+  height: number
+  docxType: DocxImageType
+}
+
+const getDocxImageTypeFromBuffer = (buffer: Buffer): DocxImageType | undefined => {
+  const format = sizeOf(buffer).type?.toLowerCase()
+  return format ? DOCX_IMAGE_TYPE_BY_FORMAT[format] : undefined
+}
+
+const fetchSurveyDocImage = async (
+  fileUuid: string | undefined,
+  fileProvider: SurveyDocOptions['fileProvider'],
+  maxWidth: number,
+  maxHeight: number
+): Promise<SurveyDocImageData | undefined> => {
+  if (!fileUuid || !fileProvider) {
+    return undefined
+  }
+
+  try {
+    const buffer = await fileProvider(fileUuid)
+    const docxType = getDocxImageTypeFromBuffer(buffer)
+    if (!docxType) {
+      return undefined
+    }
+
+    const dims = getImageDimensions(buffer)
+    const transformation = dims
+      ? calculateScaledDimensions(dims.width, dims.height, maxWidth, maxHeight)
+      : { width: maxWidth, height: maxHeight }
+
+    return {
+      buffer,
+      width: transformation.width,
+      height: transformation.height,
+      docxType,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+export const fetchSurveyDocImages = async (
+  options: Pick<SurveyDocOptions, 'fileProvider' | 'headerImageFileUuid' | 'footerImageFileUuid'>,
+  limits: { maxWidth: number; maxHeight?: number } = {
+    maxWidth: DOC_CONTENT_MAX_WIDTH,
+    maxHeight: DOC_HEADER_FOOTER_MAX_HEIGHT,
+  }
+): Promise<{ headerImage?: SurveyDocImageData; footerImage?: SurveyDocImageData }> => {
+  const { fileProvider, headerImageFileUuid, footerImageFileUuid } = options
+  const maxHeight = limits.maxHeight ?? DOC_HEADER_FOOTER_MAX_HEIGHT
+  const [headerImage, footerImage] = await Promise.all([
+    fetchSurveyDocImage(headerImageFileUuid, fileProvider, limits.maxWidth, maxHeight),
+    fetchSurveyDocImage(footerImageFileUuid, fileProvider, limits.maxWidth, maxHeight),
+  ])
+
+  return { headerImage, footerImage }
+}

--- a/src/service/survey/docExport/surveyDocImages.ts
+++ b/src/service/survey/docExport/surveyDocImages.ts
@@ -15,6 +15,14 @@ const DOCX_IMAGE_TYPE_BY_FORMAT: Record<string, DocxImageType> = {
 
 export const DOC_CONTENT_MAX_WIDTH = 650
 export const DOC_HEADER_FOOTER_MAX_HEIGHT = 120
+export const PX_TO_TWIPS = 15
+export const DOCX_MARGIN_GAP_TWIPS = 120
+
+export const isHeaderOnFirstPageOnly = (
+  options: Pick<SurveyDocOptions, 'headerOnFirstPageOnly'>
+): boolean => options.headerOnFirstPageOnly !== false
+
+export const imageHeightToTwips = (heightPx: number): number => Math.round(heightPx * PX_TO_TWIPS)
 
 export interface SurveyDocImageData {
   buffer: Buffer

--- a/src/service/survey/docExport/surveyDocImages.ts
+++ b/src/service/survey/docExport/surveyDocImages.ts
@@ -15,12 +15,16 @@ const DOCX_IMAGE_TYPE_BY_FORMAT: Record<string, DocxImageType> = {
 
 export const DOC_CONTENT_MAX_WIDTH = 650
 export const DOC_HEADER_FOOTER_MAX_HEIGHT = 120
-export const PX_TO_TWIPS = 15
-export const DOCX_MARGIN_GAP_TWIPS = 120
+export const DOC_PAGE_EDGE_MARGIN_PT = 36 // outer gap between page edge and header/footer images (shared by PDF and DOCX)
+export const DOC_HEADER_FOOTER_GAP_PT = 6 // gap between header/footer image and body content (shared by PDF and DOCX)
 
-export const isHeaderOnFirstPageOnly = (
-  options: Pick<SurveyDocOptions, 'headerOnFirstPageOnly'>
-): boolean => options.headerOnFirstPageOnly !== false
+export const PX_TO_TWIPS = 15
+export const PT_TO_TWIPS = 20
+export const DOCX_BASE_MARGIN_TWIPS = DOC_PAGE_EDGE_MARGIN_PT * PT_TO_TWIPS // 720
+export const DOCX_MARGIN_GAP_TWIPS = DOC_HEADER_FOOTER_GAP_PT * PT_TO_TWIPS // 120
+
+export const isHeaderOnFirstPageOnly = (options: Pick<SurveyDocOptions, 'headerOnFirstPageOnly'>): boolean =>
+  options.headerOnFirstPageOnly !== false
 
 export const imageHeightToTwips = (heightPx: number): number => Math.round(heightPx * PX_TO_TWIPS)
 

--- a/src/service/survey/docExport/types.ts
+++ b/src/service/survey/docExport/types.ts
@@ -17,6 +17,8 @@ export interface SurveyDocOptions {
   fileProvider?: (fileUuid: string) => Promise<Buffer>
   headerImageFileUuid?: string
   footerImageFileUuid?: string
+  /** When true (default), the header image appears only on the first page. */
+  headerOnFirstPageOnly?: boolean
 }
 
 export interface RenderContext {

--- a/src/service/survey/docExport/types.ts
+++ b/src/service/survey/docExport/types.ts
@@ -15,6 +15,8 @@ export interface SurveyDocOptions {
   i18n: I18n
   record?: ArenaRecord
   fileProvider?: (fileUuid: string) => Promise<Buffer>
+  headerImageFileUuid?: string
+  footerImageFileUuid?: string
 }
 
 export interface RenderContext {

--- a/src/service/survey/docxExport/SurveyDocxGenerator.ts
+++ b/src/service/survey/docxExport/SurveyDocxGenerator.ts
@@ -1,7 +1,13 @@
 import { AlignmentType, Document, Footer, Header, ImageRun, Packer, Paragraph } from 'docx'
 
+import {
+  DOCX_MARGIN_GAP_TWIPS,
+  fetchSurveyDocImages,
+  imageHeightToTwips,
+  isHeaderOnFirstPageOnly,
+  type SurveyDocImageData,
+} from '../docExport/surveyDocImages'
 import type { SurveyDocOptions } from '../docExport/types'
-import { fetchSurveyDocImages, type SurveyDocImageData } from '../docExport/surveyDocImages'
 import { walkSurvey } from '../docExport/SurveyDocWalker'
 import { DocxSurveyDocRenderer } from './DocxSurveyDocRenderer'
 import { convertDocxToReadOnly } from './docxReadOnlyConverter'
@@ -16,6 +22,8 @@ export interface SurveyDocxResult {
   buffer: Buffer
   surveyName: string
 }
+
+const DOCX_BASE_MARGIN_TWIPS = 720
 
 const buildDocxImageSection = (image: SurveyDocImageData): Paragraph =>
   new Paragraph({
@@ -47,6 +55,10 @@ const generateSurveyDocx = async (options: SurveyDocxOptions): Promise<SurveyDoc
   const renderer = new DocxSurveyDocRenderer()
   const { elements, surveyName } = await walkSurvey(options, renderer)
   const { headerImage, footerImage } = await fetchSurveyDocImages(options)
+  const headerOnFirstPageOnly = isHeaderOnFirstPageOnly(options)
+
+  const headerMarginTwips = headerImage ? imageHeightToTwips(headerImage.height) + DOCX_MARGIN_GAP_TWIPS : 0
+  const footerMarginTwips = footerImage ? imageHeightToTwips(footerImage.height) + DOCX_MARGIN_GAP_TWIPS : 0
 
   const doc = new Document({
     styles: {
@@ -61,11 +73,21 @@ const generateSurveyDocx = async (options: SurveyDocxOptions): Promise<SurveyDoc
     sections: [
       {
         properties: {
+          ...(headerImage && headerOnFirstPageOnly ? { titlePage: true } : {}),
           page: {
-            margin: { top: 720, bottom: 720, left: 1080, right: 1080 },
+            margin: {
+              top: DOCX_BASE_MARGIN_TWIPS + headerMarginTwips,
+              bottom: DOCX_BASE_MARGIN_TWIPS + footerMarginTwips,
+              left: 1080,
+              right: 1080,
+            },
           },
         },
-        ...(headerImage ? { headers: { default: buildDocxImageHeader(headerImage) } } : {}),
+        ...(headerImage
+          ? headerOnFirstPageOnly
+            ? { headers: { first: buildDocxImageHeader(headerImage) } }
+            : { headers: { default: buildDocxImageHeader(headerImage) } }
+          : {}),
         ...(footerImage ? { footers: { default: buildDocxImageFooter(footerImage) } } : {}),
         children: elements,
       },

--- a/src/service/survey/docxExport/SurveyDocxGenerator.ts
+++ b/src/service/survey/docxExport/SurveyDocxGenerator.ts
@@ -1,6 +1,7 @@
-import { Document, Packer } from 'docx'
+import { AlignmentType, Document, Footer, Header, ImageRun, Packer, Paragraph } from 'docx'
 
 import type { SurveyDocOptions } from '../docExport/types'
+import { fetchSurveyDocImages, type SurveyDocImageData } from '../docExport/surveyDocImages'
 import { walkSurvey } from '../docExport/SurveyDocWalker'
 import { DocxSurveyDocRenderer } from './DocxSurveyDocRenderer'
 import { convertDocxToReadOnly } from './docxReadOnlyConverter'
@@ -16,10 +17,36 @@ export interface SurveyDocxResult {
   surveyName: string
 }
 
+const buildDocxImageSection = (image: SurveyDocImageData): Paragraph =>
+  new Paragraph({
+    alignment: AlignmentType.CENTER,
+    children: [
+      new ImageRun({
+        data: image.buffer,
+        type: image.docxType,
+        transformation: {
+          width: image.width,
+          height: image.height,
+        },
+      }),
+    ],
+  })
+
+const buildDocxImageHeader = (image: SurveyDocImageData): Header =>
+  new Header({
+    children: [buildDocxImageSection(image)],
+  })
+
+const buildDocxImageFooter = (image: SurveyDocImageData): Footer =>
+  new Footer({
+    children: [buildDocxImageSection(image)],
+  })
+
 const generateSurveyDocx = async (options: SurveyDocxOptions): Promise<SurveyDocxResult> => {
   const { readOnly } = options
   const renderer = new DocxSurveyDocRenderer()
   const { elements, surveyName } = await walkSurvey(options, renderer)
+  const { headerImage, footerImage } = await fetchSurveyDocImages(options)
 
   const doc = new Document({
     styles: {
@@ -38,6 +65,8 @@ const generateSurveyDocx = async (options: SurveyDocxOptions): Promise<SurveyDoc
             margin: { top: 720, bottom: 720, left: 1080, right: 1080 },
           },
         },
+        ...(headerImage ? { headers: { default: buildDocxImageHeader(headerImage) } } : {}),
+        ...(footerImage ? { footers: { default: buildDocxImageFooter(footerImage) } } : {}),
         children: elements,
       },
     ],

--- a/src/service/survey/docxExport/SurveyDocxGenerator.ts
+++ b/src/service/survey/docxExport/SurveyDocxGenerator.ts
@@ -88,7 +88,11 @@ const generateSurveyDocx = async (options: SurveyDocxOptions): Promise<SurveyDoc
             ? { headers: { first: buildDocxImageHeader(headerImage) } }
             : { headers: { default: buildDocxImageHeader(headerImage) } }
           : {}),
-        ...(footerImage ? { footers: { default: buildDocxImageFooter(footerImage) } } : {}),
+        ...(footerImage
+          ? headerOnFirstPageOnly
+            ? { footers: { first: buildDocxImageFooter(footerImage), default: buildDocxImageFooter(footerImage) } }
+            : { footers: { default: buildDocxImageFooter(footerImage) } }
+          : {}),
         children: elements,
       },
     ],

--- a/src/service/survey/docxExport/SurveyDocxGenerator.ts
+++ b/src/service/survey/docxExport/SurveyDocxGenerator.ts
@@ -1,6 +1,7 @@
 import { AlignmentType, Document, Footer, Header, ImageRun, Packer, Paragraph } from 'docx'
 
 import {
+  DOCX_BASE_MARGIN_TWIPS,
   DOCX_MARGIN_GAP_TWIPS,
   fetchSurveyDocImages,
   imageHeightToTwips,
@@ -22,8 +23,6 @@ export interface SurveyDocxResult {
   buffer: Buffer
   surveyName: string
 }
-
-const DOCX_BASE_MARGIN_TWIPS = 720
 
 const buildDocxImageSection = (image: SurveyDocImageData): Paragraph =>
   new Paragraph({

--- a/src/service/survey/docxExport/renderers/attribute/common.ts
+++ b/src/service/survey/docxExport/renderers/attribute/common.ts
@@ -63,12 +63,14 @@ export const inputLine = (text: string): TextRun => new TextRun({ text, underlin
 export const fieldRow = (fieldLabel: string, fieldPlaceholder = EMPTY_FIELD): Paragraph =>
   new Paragraph({
     spacing: SPACING_FIELD_ROW,
+    keepLines: true,
     children: [formItemLabelRun(fieldLabel), inputLine(fieldPlaceholder)],
   })
 
 export const valueRow = (fieldLabel: string, value: string): Paragraph =>
   new Paragraph({
     spacing: SPACING_FIELD_ROW,
+    keepLines: true,
     children: [formItemLabelRun(fieldLabel), new TextRun({ text: value })],
   })
 
@@ -80,6 +82,7 @@ export const checkboxRun = (text: string, checked = false): [CheckBox, TextRun] 
 export const getTaxonFieldCommonProps = (): IParagraphOptions => ({
   spacing: { before: 0, after: 0 },
   indent: { left: 360 },
+  keepLines: true,
 })
 
 // ─── Convenience helpers still used only in docx renderers ────────────────────

--- a/src/service/survey/docxExport/renderers/attribute/renderBoolean.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderBoolean.ts
@@ -15,6 +15,7 @@ export const renderBoolean: AttributeRenderer = async ({ nodeDef, context, node 
   return [
     new Paragraph({
       spacing: SPACING_FIELD_ROW,
+      keepLines: true,
       children: [
         nodeDefFormItemLabelRun(nodeDef, context),
         ...checkboxRun(yesLabel, hasValue ? isTrue : false),

--- a/src/service/survey/docxExport/renderers/attribute/renderCode.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderCode.ts
@@ -33,6 +33,7 @@ export const renderCode: AttributeRenderer = async ({ nodeDef, context, node }) 
     return [
       new Paragraph({
         spacing: SPACING_FIELD_ROW,
+        keepLines: true,
         children: [nodeDefFormItemLabelRun(codeDef, context), ...optionRuns],
       }),
     ]

--- a/src/service/survey/docxExport/renderers/attribute/renderCoordinate.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderCoordinate.ts
@@ -23,13 +23,14 @@ export const renderCoordinate: AttributeRenderer = async ({ nodeDef, context, no
   const labelByField = getCoordinateLabelByField(coordinateDef, context)
 
   return [
-    new Paragraph({ spacing: SPACING_COMPOSITE_LABEL_ROW, children: [formItemLabelRun(lbl, false)] }),
+    new Paragraph({ spacing: SPACING_COMPOSITE_LABEL_ROW, keepNext: true, children: [formItemLabelRun(lbl, false)] }),
     ...valueFields.map((valueField) => {
       const fieldLabel = labelByField[valueField]
       const fieldValue = String(val?.[valueField] ?? EMPTY_SHORT)
       return new Paragraph({
         spacing: { before: 0, after: 0 },
         indent: { left: 360 },
+        keepLines: true,
         children: [formItemLabelRun(fieldLabel), hasValue ? new TextRun({ text: fieldValue }) : inputLine(fieldValue)],
       })
     }),

--- a/src/service/survey/docxExport/renderers/attribute/renderDate.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderDate.ts
@@ -12,6 +12,7 @@ export const renderDate: AttributeRenderer = async ({ nodeDef, context, node }) 
   return [
     new Paragraph({
       spacing: SPACING_FIELD_ROW,
+      keepLines: true,
       children: [
         nodeDefFormItemLabelRun(nodeDef, context),
         new TextRun({ text: 'DD', underline: {} }),

--- a/src/service/survey/docxExport/renderers/attribute/renderFile.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderFile.ts
@@ -17,6 +17,7 @@ const renderFilePlaceholder = (
 ): Paragraph[] => [
   new Paragraph({
     spacing: SPACING_FIELD_ROW,
+    keepLines: true,
     children: [
       nodeDefFormItemLabelRun(nodeDef, context),
       new TextRun({ text: '[file attachment]', italics: true, color: '888888' }),

--- a/src/service/survey/docxExport/renderers/attribute/renderGeo.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderGeo.ts
@@ -12,6 +12,7 @@ export const renderGeo: AttributeRenderer = async ({ nodeDef, context, node }) =
   return [
     new Paragraph({
       spacing: SPACING_FIELD_ROW,
+      keepLines: true,
       children: [
         nodeDefFormItemLabelRun(nodeDef, context),
         new TextRun({ text: '[geometry]', italics: true, color: '888888' }),

--- a/src/service/survey/docxExport/renderers/attribute/renderImage.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderImage.ts
@@ -41,6 +41,7 @@ export const renderImage = (
   return [
     new Paragraph({
       spacing: { before: 80, after: 80 },
+      keepNext: true,
       children: [formItemLabelRun(itemLabel)],
     }),
     new Paragraph({

--- a/src/service/survey/docxExport/renderers/attribute/renderTaxon.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderTaxon.ts
@@ -27,7 +27,7 @@ export const renderTaxon: AttributeRenderer = async ({ nodeDef, context, node })
   const fieldCommonProps = getTaxonFieldCommonProps()
 
   const rows: Paragraph[] = [
-    new Paragraph({ spacing: SPACING_COMPOSITE_LABEL_ROW, children: [formItemLabelRun(lbl, false)] }),
+    new Paragraph({ spacing: SPACING_COMPOSITE_LABEL_ROW, keepNext: true, children: [formItemLabelRun(lbl, false)] }),
     new Paragraph({
       ...fieldCommonProps,
       children: [

--- a/src/service/survey/docxExport/renderers/attribute/renderTime.ts
+++ b/src/service/survey/docxExport/renderers/attribute/renderTime.ts
@@ -12,6 +12,7 @@ export const renderTime: AttributeRenderer = async ({ nodeDef, context, node }) 
   return [
     new Paragraph({
       spacing: SPACING_FIELD_ROW,
+      keepLines: true,
       children: [
         nodeDefFormItemLabelRun(nodeDef, context),
         new TextRun({ text: 'HH', underline: {} }),

--- a/src/service/survey/pdfExport/SurveyPdfGenerator.ts
+++ b/src/service/survey/pdfExport/SurveyPdfGenerator.ts
@@ -1,6 +1,12 @@
 import PDFDocument from 'pdfkit'
 
-import { fetchSurveyDocImages, isHeaderOnFirstPageOnly, type SurveyDocImageData } from '../docExport/surveyDocImages'
+import {
+  DOC_HEADER_FOOTER_GAP_PT,
+  DOC_PAGE_EDGE_MARGIN_PT,
+  fetchSurveyDocImages,
+  isHeaderOnFirstPageOnly,
+  type SurveyDocImageData,
+} from '../docExport/surveyDocImages'
 import type { SurveyDocOptions } from '../docExport/types'
 import { walkSurvey } from '../docExport/SurveyDocWalker'
 import type { PdfElement } from './PdfElement'
@@ -22,7 +28,6 @@ const FONT_BOLD = 'Helvetica-Bold'
 const MARGIN = 50
 const PAGE_WIDTH = 595.28 // A4 points
 const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2
-const HEADER_FOOTER_GAP = 10
 const EMPTY_FIELD = '________________________________'
 
 const COLOR_DEFAULT = '#000000'
@@ -290,10 +295,10 @@ const drawPageDecorations = (
   headerOnFirstPageOnly: boolean
 ): void => {
   if (headerImage && (!headerOnFirstPageOnly || pageIndex === 0)) {
-    drawSurveyDocImage(doc, headerImage, MARGIN)
+    drawSurveyDocImage(doc, headerImage, DOC_PAGE_EDGE_MARGIN_PT)
   }
   if (footerImage) {
-    const footerY = doc.page.height - doc.page.margins.bottom - footerImage.height - HEADER_FOOTER_GAP
+    const footerY = doc.page.height - DOC_PAGE_EDGE_MARGIN_PT - footerImage.height
     drawSurveyDocImage(doc, footerImage, footerY)
   }
 }
@@ -308,8 +313,8 @@ const generateSurveyPdf = async (options: SurveyPdfOptions): Promise<SurveyPdfRe
 
   const headerHeight = headerImage?.height ?? 0
   const footerHeight = footerImage?.height ?? 0
-  const topMargin = MARGIN + headerHeight + (headerHeight > 0 ? HEADER_FOOTER_GAP : 0)
-  const bottomMargin = MARGIN + footerHeight + (footerHeight > 0 ? HEADER_FOOTER_GAP : 0)
+  const topMargin = DOC_PAGE_EDGE_MARGIN_PT + headerHeight + (headerHeight > 0 ? DOC_HEADER_FOOTER_GAP_PT : 0)
+  const bottomMargin = DOC_PAGE_EDGE_MARGIN_PT + footerHeight + (footerHeight > 0 ? DOC_HEADER_FOOTER_GAP_PT : 0)
 
   return new Promise<SurveyPdfResult>((resolve, reject) => {
     const doc = new PDFDocument({

--- a/src/service/survey/pdfExport/SurveyPdfGenerator.ts
+++ b/src/service/survey/pdfExport/SurveyPdfGenerator.ts
@@ -1,6 +1,6 @@
 import PDFDocument from 'pdfkit'
 
-import { fetchSurveyDocImages, type SurveyDocImageData } from '../docExport/surveyDocImages'
+import { fetchSurveyDocImages, isHeaderOnFirstPageOnly, type SurveyDocImageData } from '../docExport/surveyDocImages'
 import type { SurveyDocOptions } from '../docExport/types'
 import { walkSurvey } from '../docExport/SurveyDocWalker'
 import type { PdfElement } from './PdfElement'
@@ -35,6 +35,28 @@ const TABLE_ROW_HEIGHT = 20
 const GRID_CELL_PAD = 8 // right-side gap between grid columns
 
 type CellOpts = { x: number; width: number }
+
+const getContentBottom = (doc: PDFKit.PDFDocument): number => doc.page.height - doc.page.margins.bottom
+
+const getContentTop = (doc: PDFKit.PDFDocument): number => doc.page.margins.top
+
+const estimateElementHeight = (el: PdfElement): number => {
+  switch (el.kind) {
+    case 'image':
+      return el.height + 24
+    case 'heading':
+      return 16
+    case 'compositeBlock':
+      return 14 + el.subFields.length * 12
+    case 'checkboxRow':
+    case 'fieldRow':
+      return 14
+    case 'spacer':
+      return 8
+    default:
+      return 14
+  }
+}
 
 const renderTitle = (doc: PDFKit.PDFDocument, el: Extract<PdfElement, { kind: 'title' }>, cell?: CellOpts): void => {
   const x = cell?.x ?? MARGIN
@@ -124,7 +146,7 @@ const renderImage = (doc: PDFKit.PDFDocument, el: Extract<PdfElement, { kind: 'i
   try {
     const imgWidth = Math.min(el.width, width)
     const ratio = el.width > 0 ? imgWidth / el.width : 1
-    const contentBottom = doc.page.height - doc.page.margins.bottom
+    const contentBottom = getContentBottom(doc)
     const maxImgHeight = doc.page.height - doc.page.margins.top - doc.page.margins.bottom
     const imgHeight = Math.min(Math.round(el.height * ratio), maxImgHeight)
     // Estimate the label line height before deciding whether to add a page, so the
@@ -169,9 +191,9 @@ const renderTable = (doc: PDFKit.PDFDocument, el: Extract<PdfElement, { kind: 't
 
   const displayRows = el.rows.length > 0 ? el.rows : [el.headers.map(() => '')]
   for (const row of displayRows) {
-    if (y + TABLE_ROW_HEIGHT > doc.page.height - MARGIN) {
+    if (y + TABLE_ROW_HEIGHT > getContentBottom(doc)) {
       doc.addPage()
-      y = MARGIN
+      y = getContentTop(doc)
     }
     drawTableRow(doc, row, y, false, colWidth)
     y += TABLE_ROW_HEIGHT
@@ -187,31 +209,31 @@ let serializeElement: (doc: PDFKit.PDFDocument, el: PdfElement, cell?: CellOpts)
 const renderGridRow = (doc: PDFKit.PDFDocument, el: Extract<PdfElement, { kind: 'gridRow' }>): void => {
   const { cells, columnCount } = el
   const baseColWidth = CONTENT_WIDTH / columnCount
+  const estimatedRowHeight = Math.max(
+    TABLE_ROW_HEIGHT,
+    ...cells.map((cell) => cell.content.reduce((sum, elem) => sum + estimateElementHeight(elem), 0))
+  )
 
-  // If remaining vertical space on the current page is too small for even one text line,
-  // the first cell would trigger an auto page-break and subsequent cells would restore
-  // doc.y to the old (near-bottom) position on the new page, causing one field per page.
-  const remainingSpace = doc.page.height - doc.page.margins.bottom - doc.y
-  if (remainingSpace < TABLE_ROW_HEIGHT) {
+  // If the row cannot fit on the current page, start it on a fresh page so cells stay
+  // aligned horizontally instead of each cell landing on its own page.
+  if (doc.y + estimatedRowHeight > getContentBottom(doc)) {
     doc.addPage()
   }
 
-  const rowStartY = doc.y
+  let rowStartY = doc.y
   let maxEndY = rowStartY
   let pageBreakOccurred = false
 
   for (const cell of cells) {
     const colX = MARGIN + baseColWidth * cell.columnIndex
     const cellContentWidth = Math.max(40, baseColWidth * cell.colSpan - GRID_CELL_PAD)
-    // After a page break, stack subsequent cells below the previous one on the new
-    // page instead of restoring rowStartY (which belongs to the old page).
     doc.y = pageBreakOccurred ? maxEndY : rowStartY
     for (const elem of cell.content) {
       serializeElement(doc, elem, { x: colX, width: cellContentWidth })
     }
     if (!pageBreakOccurred && doc.y < rowStartY) {
-      // doc.y is now on a new page and lower than rowStartY from the old page.
       pageBreakOccurred = true
+      rowStartY = doc.y
       maxEndY = doc.y
     } else {
       maxEndY = Math.max(maxEndY, doc.y)
@@ -260,16 +282,19 @@ const drawSurveyDocImage = (doc: PDFKit.PDFDocument, image: SurveyDocImageData, 
   }
 }
 
-const drawHeaderFooterImages = (
+const drawPageDecorations = (
   doc: PDFKit.PDFDocument,
-  headerImage?: SurveyDocImageData,
-  footerImage?: SurveyDocImageData
+  pageIndex: number,
+  headerImage: SurveyDocImageData | undefined,
+  footerImage: SurveyDocImageData | undefined,
+  headerOnFirstPageOnly: boolean
 ): void => {
-  if (headerImage) {
+  if (headerImage && (!headerOnFirstPageOnly || pageIndex === 0)) {
     drawSurveyDocImage(doc, headerImage, MARGIN)
   }
   if (footerImage) {
-    drawSurveyDocImage(doc, footerImage, doc.page.height - MARGIN - footerImage.height)
+    const footerY = doc.page.height - doc.page.margins.bottom - footerImage.height - HEADER_FOOTER_GAP
+    drawSurveyDocImage(doc, footerImage, footerY)
   }
 }
 
@@ -279,6 +304,7 @@ const generateSurveyPdf = async (options: SurveyPdfOptions): Promise<SurveyPdfRe
   const renderer = new PdfSurveyDocRenderer()
   const { elements, surveyName } = await walkSurvey(options, renderer)
   const { headerImage, footerImage } = await fetchSurveyDocImages(options, { maxWidth: CONTENT_WIDTH })
+  const headerOnFirstPageOnly = isHeaderOnFirstPageOnly(options)
 
   const headerHeight = headerImage?.height ?? 0
   const footerHeight = footerImage?.height ?? 0
@@ -288,7 +314,6 @@ const generateSurveyPdf = async (options: SurveyPdfOptions): Promise<SurveyPdfRe
   return new Promise<SurveyPdfResult>((resolve, reject) => {
     const doc = new PDFDocument({
       size: 'A4',
-      bufferPages: true,
       margins: {
         top: topMargin,
         bottom: bottomMargin,
@@ -297,19 +322,18 @@ const generateSurveyPdf = async (options: SurveyPdfOptions): Promise<SurveyPdfRe
       },
     })
     const chunks: Buffer[] = []
+    let pageIndex = 0
 
     doc.on('data', (chunk: Buffer) => chunks.push(chunk))
     doc.on('end', () => resolve({ buffer: Buffer.concat(chunks), surveyName }))
     doc.on('error', reject)
+    doc.on('pageAdded', () => {
+      pageIndex++
+      drawPageDecorations(doc, pageIndex, headerImage, footerImage, headerOnFirstPageOnly)
+    })
 
+    drawPageDecorations(doc, 0, headerImage, footerImage, headerOnFirstPageOnly)
     serializeElements(doc, elements)
-
-    const pageRange = doc.bufferedPageRange()
-    for (let pageIndex = pageRange.start; pageIndex < pageRange.start + pageRange.count; pageIndex++) {
-      doc.switchToPage(pageIndex)
-      drawHeaderFooterImages(doc, headerImage, footerImage)
-    }
-
     doc.end()
   })
 }

--- a/src/service/survey/pdfExport/SurveyPdfGenerator.ts
+++ b/src/service/survey/pdfExport/SurveyPdfGenerator.ts
@@ -229,7 +229,8 @@ const drawSurveyDocImage = (
   y: number
 ): void => {
   try {
-    doc.image(image.buffer, MARGIN, y, { width: image.width, height: image.height })
+    const x = MARGIN + (CONTENT_WIDTH - image.width) / 2
+    doc.image(image.buffer, x, y, { width: image.width, height: image.height })
   } catch {
     // Ignore unsupported or corrupted image data.
   }

--- a/src/service/survey/pdfExport/SurveyPdfGenerator.ts
+++ b/src/service/survey/pdfExport/SurveyPdfGenerator.ts
@@ -177,6 +177,15 @@ let serializeElement: (doc: PDFKit.PDFDocument, el: PdfElement, cell?: CellOpts)
 const renderGridRow = (doc: PDFKit.PDFDocument, el: Extract<PdfElement, { kind: 'gridRow' }>): void => {
   const { cells, columnCount } = el
   const baseColWidth = CONTENT_WIDTH / columnCount
+
+  // If remaining vertical space on the current page is too small for even one text line,
+  // the first cell would trigger an auto page-break and subsequent cells would restore
+  // doc.y to the old (near-bottom) position on the new page, causing one field per page.
+  const remainingSpace = doc.page.height - doc.page.margins.bottom - doc.y
+  if (remainingSpace < TABLE_ROW_HEIGHT) {
+    doc.addPage()
+  }
+
   const rowStartY = doc.y
   let maxEndY = rowStartY
 
@@ -223,11 +232,7 @@ const serializeElements = (doc: PDFKit.PDFDocument, elements: PdfElement[]): voi
   for (const el of elements) serializeElement(doc, el)
 }
 
-const drawSurveyDocImage = (
-  doc: PDFKit.PDFDocument,
-  image: SurveyDocImageData,
-  y: number
-): void => {
+const drawSurveyDocImage = (doc: PDFKit.PDFDocument, image: SurveyDocImageData, y: number): void => {
   try {
     const x = MARGIN + (CONTENT_WIDTH - image.width) / 2
     doc.image(image.buffer, x, y, { width: image.width, height: image.height })

--- a/src/service/survey/pdfExport/SurveyPdfGenerator.ts
+++ b/src/service/survey/pdfExport/SurveyPdfGenerator.ts
@@ -1,5 +1,6 @@
 import PDFDocument from 'pdfkit'
 
+import { fetchSurveyDocImages, type SurveyDocImageData } from '../docExport/surveyDocImages'
 import type { SurveyDocOptions } from '../docExport/types'
 import { walkSurvey } from '../docExport/SurveyDocWalker'
 import type { PdfElement } from './PdfElement'
@@ -21,6 +22,7 @@ const FONT_BOLD = 'Helvetica-Bold'
 const MARGIN = 50
 const PAGE_WIDTH = 595.28 // A4 points
 const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2
+const HEADER_FOOTER_GAP = 10
 const EMPTY_FIELD = '________________________________'
 
 const COLOR_DEFAULT = '#000000'
@@ -221,14 +223,54 @@ const serializeElements = (doc: PDFKit.PDFDocument, elements: PdfElement[]): voi
   for (const el of elements) serializeElement(doc, el)
 }
 
+const drawSurveyDocImage = (
+  doc: PDFKit.PDFDocument,
+  image: SurveyDocImageData,
+  y: number
+): void => {
+  try {
+    doc.image(image.buffer, MARGIN, y, { width: image.width, height: image.height })
+  } catch {
+    // Ignore unsupported or corrupted image data.
+  }
+}
+
+const drawHeaderFooterImages = (
+  doc: PDFKit.PDFDocument,
+  headerImage?: SurveyDocImageData,
+  footerImage?: SurveyDocImageData
+): void => {
+  if (headerImage) {
+    drawSurveyDocImage(doc, headerImage, MARGIN)
+  }
+  if (footerImage) {
+    drawSurveyDocImage(doc, footerImage, doc.page.height - MARGIN - footerImage.height)
+  }
+}
+
 // ─── Generator ────────────────────────────────────────────────────────────────
 
 const generateSurveyPdf = async (options: SurveyPdfOptions): Promise<SurveyPdfResult> => {
   const renderer = new PdfSurveyDocRenderer()
   const { elements, surveyName } = await walkSurvey(options, renderer)
+  const { headerImage, footerImage } = await fetchSurveyDocImages(options, { maxWidth: CONTENT_WIDTH })
+
+  const headerHeight = headerImage?.height ?? 0
+  const footerHeight = footerImage?.height ?? 0
+  const topMargin = MARGIN + headerHeight + (headerHeight > 0 ? HEADER_FOOTER_GAP : 0)
+  const bottomMargin = MARGIN + footerHeight + (footerHeight > 0 ? HEADER_FOOTER_GAP : 0)
 
   return new Promise<SurveyPdfResult>((resolve, reject) => {
-    const doc = new PDFDocument({ margin: MARGIN, size: 'A4' })
+    const doc = new PDFDocument({
+      size: 'A4',
+      bufferPages: true,
+      margins: {
+        top: topMargin,
+        bottom: bottomMargin,
+        left: MARGIN,
+        right: MARGIN,
+      },
+    })
     const chunks: Buffer[] = []
 
     doc.on('data', (chunk: Buffer) => chunks.push(chunk))
@@ -236,6 +278,13 @@ const generateSurveyPdf = async (options: SurveyPdfOptions): Promise<SurveyPdfRe
     doc.on('error', reject)
 
     serializeElements(doc, elements)
+
+    const pageRange = doc.bufferedPageRange()
+    for (let pageIndex = pageRange.start; pageIndex < pageRange.start + pageRange.count; pageIndex++) {
+      doc.switchToPage(pageIndex)
+      drawHeaderFooterImages(doc, headerImage, footerImage)
+    }
+
     doc.end()
   })
 }

--- a/src/service/survey/pdfExport/SurveyPdfGenerator.ts
+++ b/src/service/survey/pdfExport/SurveyPdfGenerator.ts
@@ -121,16 +121,26 @@ const renderCompositeBlock = (
 const renderImage = (doc: PDFKit.PDFDocument, el: Extract<PdfElement, { kind: 'image' }>, cell?: CellOpts): void => {
   const x = cell?.x ?? MARGIN
   const width = cell?.width ?? CONTENT_WIDTH
-  doc.font(FONT_BOLD).fontSize(10).text(`${el.label}:`, x, doc.y, { width }).moveDown(0.1)
   try {
     const imgWidth = Math.min(el.width, width)
     const ratio = el.width > 0 ? imgWidth / el.width : 1
-    const imgHeight = Math.round(el.height * ratio)
+    const contentBottom = doc.page.height - doc.page.margins.bottom
+    const maxImgHeight = doc.page.height - doc.page.margins.top - doc.page.margins.bottom
+    const imgHeight = Math.min(Math.round(el.height * ratio), maxImgHeight)
+    // Estimate the label line height before deciding whether to add a page, so the
+    // label and the image always land on the same page.
+    doc.font(FONT_BOLD).fontSize(10)
+    const labelHeight = doc.currentLineHeight(true) * 1.1
+    if (doc.y + labelHeight + imgHeight > contentBottom) {
+      doc.addPage()
+    }
+    doc.text(`${el.label}:`, x, doc.y, { width }).moveDown(0.1)
     const imageY = doc.y
     doc.image(el.buffer, x, imageY, { width: imgWidth, height: imgHeight })
     doc.y = imageY + imgHeight
   } catch {
-    doc.font(FONT_NORMAL).fontSize(10).text('[image]', x, doc.y, { width })
+    doc.font(FONT_BOLD).fontSize(10).text(`${el.label}:`, x, doc.y, { width })
+    doc.font(FONT_NORMAL).text('[image]', x, doc.y, { width })
   }
   doc.moveDown(0.3)
 }
@@ -188,15 +198,24 @@ const renderGridRow = (doc: PDFKit.PDFDocument, el: Extract<PdfElement, { kind: 
 
   const rowStartY = doc.y
   let maxEndY = rowStartY
+  let pageBreakOccurred = false
 
   for (const cell of cells) {
     const colX = MARGIN + baseColWidth * cell.columnIndex
     const cellContentWidth = Math.max(40, baseColWidth * cell.colSpan - GRID_CELL_PAD)
-    doc.y = rowStartY
+    // After a page break, stack subsequent cells below the previous one on the new
+    // page instead of restoring rowStartY (which belongs to the old page).
+    doc.y = pageBreakOccurred ? maxEndY : rowStartY
     for (const elem of cell.content) {
       serializeElement(doc, elem, { x: colX, width: cellContentWidth })
     }
-    maxEndY = Math.max(maxEndY, doc.y)
+    if (!pageBreakOccurred && doc.y < rowStartY) {
+      // doc.y is now on a new page and lower than rowStartY from the old page.
+      pageBreakOccurred = true
+      maxEndY = doc.y
+    } else {
+      maxEndY = Math.max(maxEndY, doc.y)
+    }
   }
 
   doc.y = maxEndY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds support for optional survey document header and footer images in arena-server, matching the arena-side work on `feat/survey-doc-images`.

- Extends `SurveyDocOptions` with optional `headerImageFileUuid` and `footerImageFileUuid`
- Fetches image buffers via the existing `fileProvider` callback when UUIDs are provided
- Embeds images in DOCX headers/footers and draws them in PDF exports
- Scales images to content width (max height 120px) while preserving aspect ratio

## Latest updates (Stefano + Copilot feedback)

- **`headerOnFirstPageOnly`** option added (default `true`) — header image on first page only; footer on all pages
- **DOCX**: `titlePage` + `headers.first` for first-page-only mode; dynamic top/bottom margins based on image height
- **PDF grid layout**: improved row height estimation and page-break handling so multi-column rows stay on one page
- **PDF**: replaced `bufferPages` with `pageAdded` handler (lower memory use)
- **PDF**: table pagination now uses `doc.page.margins` instead of fixed `MARGIN`

Builds on Stefano's commits on this branch (`fixed form items overflow`, `fixed file attribute rendering`).

## Arena integration

Arena's `exportSurveyDocument` passes header/footer UUIDs via `fileProvider`. Record export needs the same wiring on `feat/survey-doc-images`.

## Testing

```bash
# arena-server
yarn build

# arena (feat/survey-doc-images)
yarn add ../arena-server
```

Export survey/record DOCX/PDF with header/footer images configured in Survey Info.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34df3700-47cd-41c5-8068-83a091e0d2d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34df3700-47cd-41c5-8068-83a091e0d2d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

