### PR TITLE
chore: use latest arena-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@godaddy/terminus": "^4.12.1",
-    "@openforis/arena-core": "^1.4.0",
+    "@openforis/arena-core": "^1.4.1",
     "bcryptjs": "^3.0.3",
     "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,9 +1037,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openforis/arena-core@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@openforis/arena-core@npm:1.4.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40openforis%2Farena-core%2F1.4.0%2F0e8b6d5fb3f3c1f934d8319d204ee8b3547c1cb0"
+"@openforis/arena-core@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "@openforis/arena-core@npm:1.4.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40openforis%2Farena-core%2F1.4.1%2Fc46dd37ce6fa46a845221a0a4b5469d0c11238c1"
   dependencies:
     "@jsep-plugin/regex": "npm:^1.0.4"
     "@turf/bearing": "npm:^7.3.5"
@@ -1055,7 +1055,7 @@ __metadata:
     moment: "npm:^2.30.1"
     proj4: "npm:^2.20.9"
     uuid: "npm:^14.0.1"
-  checksum: 10c0/5af2b3364caa52140df5fc279ffa8efbd9845e2f29103f4315d80643f3911ab4ad8d9caa1f5b2ae46f6d3be533a3d4aaef2392da41ac6779b9108f005a43232b
+  checksum: 10c0/810dad8087711fbedccff37c8109b7d0b0d2f6e880dc5c3c66d94d81fee4938b2951695557ef193a1ecd7eb944c5d86fe144ae86086124b9718bdb543f82eb6d
   languageName: node
   linkType: hard
 
@@ -1066,7 +1066,7 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@godaddy/terminus": "npm:^4.12.1"
     "@machinomy/types-node-db-migrate": "npm:^0.0.2"
-    "@openforis/arena-core": "npm:^1.4.0"
+    "@openforis/arena-core": "npm:^1.4.1"
     "@types/bcryptjs": "npm:^3.0.0"
     "@types/compression": "npm:^1.8.1"
     "@types/cookie-parser": "npm:^1.4.10"


### PR DESCRIPTION
## Summary
- Bump `@openforis/arena-core` from `^1.4.0` to `^1.4.1`.
- Pulls in the page validation fix that includes attribute/file `childrenCount_*` errors in page status (while still ignoring descendant-page entity counts).

## Test plan
- [x] CI passes / package installs cleanly
- [x] After auto-release, Arena can bump to the new arena-server version
- [x] Record entry: mandatory file left empty keeps sidebar red icon after other fields are filled